### PR TITLE
Fix resource leak in http client

### DIFF
--- a/SPiDSDK/src/main/java/com/spid/android/sdk/reponse/SPiDResponse.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/reponse/SPiDResponse.java
@@ -14,7 +14,6 @@ import org.json.JSONObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,16 +52,13 @@ public class SPiDResponse {
         this.headers = new HashMap<String, String>();
         this.exception = null;
         BufferedReader reader = null;
-        InputStreamReader inputStreamReader = null;
 
         for (Header header : httpResponse.getAllHeaders()) {
             this.headers.put(header.getName(), header.getValue());
         }
 
         try {
-            inputStreamReader = new InputStreamReader(httpResponse.getEntity().getContent());
-            reader = new BufferedReader(inputStreamReader);
-
+            reader = new BufferedReader(new InputStreamReader(httpResponse.getEntity().getContent()));
             StringBuilder builder = new StringBuilder();
             String line = reader.readLine();
             while (line != null) {
@@ -73,7 +69,6 @@ public class SPiDResponse {
         } catch (IOException exception) {
             this.exception = exception;
         } finally {
-            closeQuietly(inputStreamReader);
             closeQuietly(reader);
         }
 
@@ -97,7 +92,7 @@ public class SPiDResponse {
         }
     }
 
-    private void closeQuietly(Reader reader) {
+    private void closeQuietly(BufferedReader reader) {
         if(reader != null) {
             try {
                 reader.close();

--- a/SPiDSDK/src/main/java/com/spid/android/sdk/reponse/SPiDResponse.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/reponse/SPiDResponse.java
@@ -14,6 +14,7 @@ import org.json.JSONObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,13 +53,16 @@ public class SPiDResponse {
         this.headers = new HashMap<String, String>();
         this.exception = null;
         BufferedReader reader = null;
+        InputStreamReader inputStreamReader = null;
 
         for (Header header : httpResponse.getAllHeaders()) {
             this.headers.put(header.getName(), header.getValue());
         }
 
         try {
-            reader = new BufferedReader(new InputStreamReader(httpResponse.getEntity().getContent()));
+            inputStreamReader = new InputStreamReader(httpResponse.getEntity().getContent());
+            reader = new BufferedReader(inputStreamReader);
+
             StringBuilder builder = new StringBuilder();
             String line = reader.readLine();
             while (line != null) {
@@ -69,6 +73,7 @@ public class SPiDResponse {
         } catch (IOException exception) {
             this.exception = exception;
         } finally {
+            closeQuietly(inputStreamReader);
             closeQuietly(reader);
         }
 
@@ -92,7 +97,7 @@ public class SPiDResponse {
         }
     }
 
-    private void closeQuietly(BufferedReader reader) {
+    private void closeQuietly(Reader reader) {
         if(reader != null) {
             try {
                 reader.close();

--- a/SPiDSDK/src/main/java/com/spid/android/sdk/request/SPiDRequest.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/request/SPiDRequest.java
@@ -220,7 +220,7 @@ public class SPiDRequest extends AsyncTask<Void, Void, SPiDResponse> {
 
             HttpClientParams.setRedirecting(httpRequest.getParams(), false);
 
-            HttpClient httpClient = new DefaultHttpClient();
+            HttpClient httpClient = AndroidHttpClient.newInstance(SPiDClient.getInstance().getConfig().getUserAgent());
             HttpResponse httpResponse = httpClient.execute(httpRequest);
 
             return new SPiDResponse(httpResponse);


### PR DESCRIPTION
There is a bug on Nexus 5 (Android 5.0.1) which leaks resources. Replacing DefaultHttpClient with AndroidHttpClient fixed issue.