### PR TITLE
Catch exceptions in else block when refreshing SPiD tokens.

### DIFF
--- a/SPiDSDK/src/main/java/com/spid/android/sdk/accesstoken/SPiDAccessToken.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/accesstoken/SPiDAccessToken.java
@@ -41,7 +41,7 @@ public class SPiDAccessToken {
             // Optional values
             this.refreshToken = jsonObject.optString(REFRESH_SPID_ACCESS_TOKEN_KEY, null);
             this.userID = jsonObject.optString(SPID_ACCESS_TOKEN_USER_ID, null);
-        } catch (JSONException e) {
+        } catch (Exception e) { // Could be NullPointerException, JsonException (and more?)
             throw new SPiDAccessTokenException("Received invalid access token data");
         }
     }

--- a/SPiDSDK/src/main/java/com/spid/android/sdk/request/SPiDTokenRequest.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/request/SPiDTokenRequest.java
@@ -2,6 +2,7 @@ package com.spid.android.sdk.request;
 
 import com.spid.android.sdk.SPiDClient;
 import com.spid.android.sdk.accesstoken.SPiDAccessToken;
+import com.spid.android.sdk.exceptions.SPiDAccessTokenException;
 import com.spid.android.sdk.keychain.SPiDKeychain;
 import com.spid.android.sdk.listener.SPiDAuthorizationListener;
 import com.spid.android.sdk.response.SPiDResponse;
@@ -39,12 +40,19 @@ public class SPiDTokenRequest extends SPiDRequest {
                 // no listener registered, do nothing
             }
         } else {
-            SPiDAccessToken token = new SPiDAccessToken(response.getJsonObject());
-            SPiDClient.getInstance().setAccessToken(token);
-            SPiDKeychain.encryptAccessTokenToSharedPreferences(SPiDClient.getInstance().getConfig().getClientSecret(), token);
-            SPiDClient.getInstance().runWaitingRequests();
-            if (authorizationListener != null)
-                authorizationListener.onComplete();
+            try {
+                SPiDAccessToken token = new SPiDAccessToken(response.getJsonObject());
+                SPiDClient.getInstance().setAccessToken(token);
+                SPiDKeychain.encryptAccessTokenToSharedPreferences(SPiDClient.getInstance().getConfig().getClientSecret(), token);
+                SPiDClient.getInstance().runWaitingRequests();
+                if (authorizationListener != null)
+                    authorizationListener.onComplete();
+            }
+            catch (Exception ex) {
+                if(authorizationListener != null) {
+                    authorizationListener.onError(ex);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
May occur if proxy configured wrong or similar cases.