### PR TITLE
Add new methods to get and accept agreements

### DIFF
--- a/SPiDNativeApp/build.gradle
+++ b/SPiDNativeApp/build.gradle
@@ -16,14 +16,7 @@ android {
     }
 }
 
-repositories {
-    maven { url 'https://raw.github.com/schibsted/sdk-android/master/SPiDSDK/repo/' }
-    flatDir {
-        dirs 'lib'
-    }
-}
-
 dependencies {
-    compile 'no.schibstedpayment:SPiD-Android:1.3.10@aar'
+    compile project(':SPiDSDK')
     compile 'com.android.support:support-v4:23.1.1'
 }

--- a/SPiDNativeApp/src/main/java/com/spid/android/example/nativeapp/MainActivity.java
+++ b/SPiDNativeApp/src/main/java/com/spid/android/example/nativeapp/MainActivity.java
@@ -77,6 +77,12 @@ public class MainActivity extends Activity {
         Button logoutButton = (Button) findViewById(R.id.activity_main_button_logout);
         logoutButton.setOnClickListener(new LogoutButtonListener(this));
 
+        Button getAgreementsButton = (Button) findViewById(R.id.activity_main_button_agreements);
+        getAgreementsButton.setOnClickListener(new GetAgreementsButtonListener(this));
+
+        Button acceptAgreementButton = (Button) findViewById(R.id.activity_main_button_accept_agreement);
+        acceptAgreementButton.setOnClickListener(new AcceptAgreementButtonListener(this));
+
         fetchUserInfo();
     }
 
@@ -196,6 +202,67 @@ public class MainActivity extends Activity {
                     SPiDLogger.log("Error logging out: " + exception.getMessage());
                     Toast.makeText(context, "Error logging out...", Toast.LENGTH_LONG).show();
                     recreate();
+                }
+            });
+        }
+    }
+
+    private class GetAgreementsButtonListener implements View.OnClickListener {
+        final Context context;
+
+        private GetAgreementsButtonListener(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void onClick(View v) {
+            SPiDClient.getInstance().getAgreements(new SPiDRequestListener() {
+                @Override
+                public void onComplete(SPiDResponse result) {
+                    try {
+                        JSONObject agreementsJsonObject = result.getJsonObject().getJSONObject("data").getJSONObject("agreements");
+                        boolean platform = agreementsJsonObject.getBoolean("platform");
+                        boolean client = agreementsJsonObject.getBoolean("client");
+
+                        String message = "Platform: " + (platform ? "Accepted" : "Not accepted");
+                        message += "\n";
+                        message += "Client: " + (client ? "Accepted" : "Not accepted");
+
+                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
+                    } catch (JSONException exception) {
+                        SPiDLogger.log("Error decoding agreements from SPiD: " + exception.getMessage());
+                        Toast.makeText(context, "Unable to load agreements", Toast.LENGTH_LONG).show();
+                    }
+                }
+
+                @Override
+                public void onError(Exception exception) {
+                    SPiDLogger.log("Error getting agreements: " + exception.getMessage());
+                    Toast.makeText(context, "Error getting agreements...", Toast.LENGTH_LONG).show();
+                }
+            });
+        }
+    }
+
+    private class AcceptAgreementButtonListener implements View.OnClickListener {
+        final Context context;
+
+        private AcceptAgreementButtonListener(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void onClick(View v) {
+            SPiDClient.getInstance().acceptAgreements(new SPiDRequestListener() {
+                @Override
+                public void onComplete(SPiDResponse result) {
+                    Toast.makeText(context, "Agreement accepted", Toast.LENGTH_SHORT).show();
+                }
+
+                @Override
+                public void onError(Exception exception) {
+                    SPiDLogger.log("Error accepting ageement: " + exception.getMessage());
+                    Toast.makeText(context, "Error accepting ageement...", Toast.LENGTH_LONG).show();
                 }
             });
         }

--- a/SPiDNativeApp/src/main/res/layout/activity_main.xml
+++ b/SPiDNativeApp/src/main/res/layout/activity_main.xml
@@ -45,6 +45,24 @@
             android:background="@android:color/darker_gray" />
 
         <Button
+            android:id="@+id/activity_main_button_agreements"
+            style="@android:style/Widget.Holo.Light.Button.Borderless.Small"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="18sp"
+            android:text="@string/getAgreements" />
+
+        <Button
+            android:id="@+id/activity_main_button_accept_agreement"
+            style="@android:style/Widget.Holo.Light.Button.Borderless.Small"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="18sp"
+            android:text="@string/acceptAgreement" />
+
+        <Button
             android:id="@+id/activity_main_button_logout"
             style="@android:style/Widget.Holo.Light.Button.Borderless.Small"
             android:layout_width="fill_parent"

--- a/SPiDNativeApp/src/main/res/values/strings.xml
+++ b/SPiDNativeApp/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="agreementToTerms">By using this service you are agreeing to the</string>
     <string name="newUser">New user?</string>
     <string name="termsOfUse">Terms of use</string>
+    <string name="getAgreements">Get agreements</string>
+    <string name="acceptAgreement">Accept agreement</string>
 </resources>

--- a/SPiDSDK/src/main/java/com/spid/android/sdk/SPiDClient.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/SPiDClient.java
@@ -319,6 +319,26 @@ public class SPiDClient {
     }
 
     /**
+     * Request wrapper to get agreements
+     *
+     * @param listener Listener called on completion or failure, can be <code>null</code>
+     */
+    public void getAgreements(SPiDRequestListener listener) {
+        SPiDRequest request = new SPiDApiGetRequest("/user/" + token.getUserID() + "/agreements", listener);
+        request.executeAuthorizedRequest();
+    }
+
+    /**
+     * Request wrapper to accept both the client and the platform agreement
+     *
+     * @param listener Listener called on completion or failure, can be <code>null</code>
+     */
+    public void acceptAgreements(SPiDRequestListener listener) {
+        SPiDRequest request = new SPiDApiPostRequest("/user/" + token.getUserID() + "/agreements/accept", listener);
+        request.executeAuthorizedRequest();
+    }
+
+    /**
      * Runs requests that have been on hold during authentication
      */
     public void runWaitingRequests() {


### PR DESCRIPTION
I added two new methods to `SPiDClient`:
- `getAgreements` which returns all agreements for the current user
- `acceptAgreements` which allows to accept both the client and the platform agreement

I used `getAgreements` name because `GET user/{userId}/agreements` returns client and platform agreements statuses, not pending. I did not bother filtering on only the non-accepted agreements, as that would made the task much bigger, require JSON manipulation.

I also updated SPiDNativeApp project to show how to use new methods.

Fixes #18.