### PR TITLE
Update to version 1.3.11

### DIFF
--- a/SPiDSDK/build.gradle
+++ b/SPiDSDK/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-project.version = '1.3.10'
+project.version = '1.3.11'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/SPiDSDK/src/main/java/com/spid/android/sdk/SPiDClient.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/SPiDClient.java
@@ -30,9 +30,6 @@ import java.util.List;
  * Main class for SPiD, contains a singleton
  */
 public class SPiDClient {
-
-    public static final String SPID_ANDROID_SDK_VERSION_STRING = "1.3.9";
-
     public static final String OAUTH_TOKEN = "oauth_token";
 
     private static final SPiDClient instance = new SPiDClient();

--- a/SPiDSDK/src/main/java/com/spid/android/sdk/configuration/SPiDConfigurationBuilder.java
+++ b/SPiDSDK/src/main/java/com/spid/android/sdk/configuration/SPiDConfigurationBuilder.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
 
+import com.spid.android.sdk.BuildConfig;
 import com.spid.android.sdk.SPiDClient;
 import com.spid.android.sdk.logger.SPiDLogger;
 
@@ -187,7 +188,7 @@ public class SPiDConfigurationBuilder {
         String applicationName = (String) (applicationInfo != null ? packageManager.getApplicationLabel(applicationInfo) : "UnknownApplication");
         String applicationVersion = packageInfo != null ? packageInfo.versionName : "UnknownVersion";
 
-        return applicationName + "/" + applicationVersion + " " + "SPiDAndroidSDK/" + SPiDClient.SPID_ANDROID_SDK_VERSION_STRING + " " + "Android/" + android.os.Build.MODEL + "/API " + Build.VERSION.SDK_INT;
+        return applicationName + "/" + applicationVersion + " " + "SPiDAndroidSDK/" + BuildConfig.VERSION_NAME + " " + "Android/" + android.os.Build.MODEL + "/API " + Build.VERSION.SDK_INT;
     }
 
     /**


### PR DESCRIPTION
Update the version code. v1.3.11 will now be the version with the new t&c endpoint code
ref https://github.com/schibsted/sdk-android/issues/18

*edit*: Now bumped to 1.3.12 because 1.3.11 is released but with 1.3.9 as version code in the user agent, which is wrong